### PR TITLE
Netlify site cleanup (removed feedback, create doc issue, and contribution guideline links)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -115,7 +115,7 @@ footer_about_disable = true
 # If you want this feature, but occasionally need to remove the "Feedback" section from a single page,
 # add "hide_feedback: true" to the page's front matter.
 [params.ui.feedback]
-enable = true
+enable = false
 # The responses that the user sees after clicking "yes" (the page was helpful) or "no" (the page was not helpful).
 yes = 'Glad to hear it! Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'
 no = 'Sorry to hear that. Please <a href="https://github.com/Axway/axway-open-docs/issues/new">tell us how we can improve</a>.'

--- a/layouts/docs/list.html
+++ b/layouts/docs/list.html
@@ -17,6 +17,6 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>
 {{ end }}

--- a/layouts/partials/page-meta-links.html
+++ b/layouts/partials/page-meta-links.html
@@ -31,14 +31,6 @@
 {{ end }} <!-- end of with -->
 {{ $cmsURL := printf "%s/admin/#/edit/%s/%s" $baseURL $cms_collection .File.BaseFileName }}
 <a href="{{ $cmsURL }}" target="_blank"><i class="fas fa-columns fa-fw"></i> {{ T "post_edit_cms" }}</a>
-{{ $issuesURL := printf "%s/issues/new?template=documentation-issue-template.md&title=%s" $gh_repo (htmlEscape $.Title )}}
-<a href="{{ $issuesURL }}" target="_blank"><i class="fab fa-github fa-fw"></i> {{ T "post_create_issue" }}</a>
-{{ if $gh_project_repo }}
-{{ $project_issueURL := printf "%s/issues/new" $gh_project_repo }}
-<a href="{{ $project_issueURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "post_create_project_issue" }}</a>
-{{ end }} <!-- end of if proj repo -->
-{{ $contributionURL := printf "%s/docs/contribution_guidelines/" $baseURL }}
-<a href="{{ $contributionURL }}" target="_blank"><i class="fas fa-tasks fa-fw"></i> {{ T "contribution_guidelines" }}</a>
 </div>
 {{ end }} <!-- end of if repo -->
 {{ end }} <!-- end if path -->


### PR DESCRIPTION
Thank you for your contribution to the API Builder documentation.

## Describe the changes

Project cleanup changes for the Netlify site: removed the feedback section and extra line from the bottom of the site and removed the Create Documentation Issue and Contribution Guidelines links from the right navigation.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._