### PR TITLE
Delete extra horizontal line at bottom of Netlify content pages

### DIFF
--- a/layouts/_default/content.html
+++ b/layouts/_default/content.html
@@ -15,5 +15,5 @@
 		<br />
 		{{ partial "disqus-comment.html" . }}
 	{{ end }}
-	<div class="text-muted mt-5 pt-3 border-top">{{ partial "page-meta-lastmod.html" . }}</div>
+	{{ partial "page-meta-lastmod.html" . }}
 </div>


### PR DESCRIPTION
Thank you for your contribution to the API Builder documentation.

## Describe the changes

After removing the Feedback section at the bottom of the Netlify page, an extra horizontal section line remained and needs to be deleted. This removes it from the "content" (2nd level heading) pages.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._