### PR TITLE
Update build script so Netlify build fails when Hugo build fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,9 @@
 #     if they change
 #
 
+
+set -e
+
 DEBUG=${DEBUG:-false}
 MODE=dev
 while getopts ":np" opt; do
@@ -166,3 +169,4 @@ function fRunHugo() {
 fCheckoutSubmodule
 fMergeContent
 fRunHugo
+echo "[INFO] Done"


### PR DESCRIPTION
Thank you for your contribution to the API Builder documentation.

## Describe the changes

Update the project build script to fail the Netlify build process and show an error in the Netlify dashboard when the Hugo build fails.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._