### PR TITLE
Remove broken links to billing and subscription usage guide 1.0

### DIFF
--- a/content/en/docs/how_to/track_usage_for_your_subscription.md
+++ b/content/en/docs/how_to/track_usage_for_your_subscription.md
@@ -7,7 +7,7 @@ date: 2021-10-01
 
 ## Overview
 
-Each {{% variables/apibuilder_prod_name %}} integration that you create can report its own transaction usage to the platform without the need for an agent. Transactions are reported against Environments in your Organization, and you can review these transactions along with those from [other Amplify products](https://docs.axway.com/bundle/subusage_11_en/page/amplify_subscription_usage_and_reporting.html). For more information, see [Subscription Usage Tracking](https://docs.axway.com/bundle/subusage_11_en/page/about_subscription_usage_tracking.html) and [Manage Billing](https://docs.axway.com/bundle/platform-management/page/docs/management_guide/managing_billing/index.html).
+Each {{% variables/apibuilder_prod_name %}} integration that you create can report its own transaction usage to the platform without the need for an agent. Transactions are reported against Environments in your Organization, and you can review these transactions along with those from [other Amplify products](https://docs.axway.com/bundle/subusage_11_en/page/amplify_subscription_usage_and_reporting.html). For more information, see [Subscription Usage Tracking](https://docs.axway.com/bundle/subusage_11_en/page/about_subscription_usage_tracking.html).
 
 ### What is counted as a transaction?
 
@@ -106,7 +106,7 @@ When you want to track transaction usage, in your target environment, you need t
 
 ### subscriptionUsageTracking
 
-This configuration is used to configure {{% variables/apibuilder_prod_name %}} [usage tracking for the {{% variables/platform_prod_name %}}](https://docs.axway.com/bundle/subusage_en/page/amplify_subscription_usage_and_reporting.html). Certain keys are only applicable when using specific reporters. These are identified in the final column.
+This configuration is used to configure {{% variables/apibuilder_prod_name %}}. Certain keys are only applicable when using specific reporters. These are identified in the final column.
 
 | Key | Type | Description | Required | Default | Applicable reporters |
 | --- | --- | --- | --- | --- | --- |


### PR DESCRIPTION
Thank you for your contribution to the API Builder documentation.

## Describe the changes

Removed broken links to the billing topic that was removed from the Platform guide (and not needed; tokens are from the bundle subscription) and to the Amplify Subscription Usage for Edge Agent 1.0 since that doc is no longer used. It's not necessary to link it to the 1.1 guide because there is no relevant content since the details are in the API Builder topic.

## Checklist for contributors

Before submitting this PR, please make sure:

* [ ] You have read the [contribution guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/)
* [ ] You have signed the [Axway CLA](https://cla.axway.com/)
* [ ] You have verified the technical accuracy of your change
* [ ] You have verified that your change does not expose any sensitive information (passwords, keys, etc.)
* [ ] You have followed the [Markdown guidelines](https://axway-open-docs.netlify.com/docs/contribution_guidelines/writing_markdown/)  (unless this is is a Netlify CMS contribution)
* [ ] You have verified that all status checks have passed

_Put an x in the boxes that apply. This is simply a reminder of what we are going to look for before merging your change._